### PR TITLE
Add battery calibration guide and LED health mapping

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -18,6 +18,8 @@ This Guide is split up into multiple "subguides":
 
 - [[CLI|cli]]: The official way to control your Chameleon is via the **C**ommand **L**ine **I**nterface (CLI). Learn how to install and master the CLI.
 
+- [[Battery calibration|battery-calibration]]: Recommended battery calibration procedure and LED health mapping.
+
 - [[GUIs|gui]]: Some people also develop **G**raphical **U**ser **I**nterfaces (GUIs), these may be a good start for people that do not want to deal with a CLI.
 
 - [[Troubleshooting|troubleshooting]]: For when things go wrong, here are some common tips to maybe fix whatever issue you might have.

--- a/battery-calibration.md
+++ b/battery-calibration.md
@@ -30,8 +30,6 @@ The Lite uses a smaller button cell than the Ultra, but both variants use the sa
   | `critical` | red | 2 extra blinks |
 
 - If the reported percentage dips below `100%` immediately after a full charge, the curve reference is too high for that board.
-- A reading around `3160 mV` would not be consistent with a fully charged single-cell LiPo, so treat that value as a typo unless you have board-specific evidence to the contrary.
-
 ## Notes
 
 - Battery reads are most reliable after wake-up, once the analog path has settled.

--- a/battery-calibration.md
+++ b/battery-calibration.md
@@ -1,0 +1,37 @@
+# Battery Calibration
+
+The battery percentage is derived from the reported battery voltage using an empirically tuned curve.
+The default curve is calibrated so that the lowest stable full-charge voltage still maps to 100%.
+The Lite uses a smaller button cell than the Ultra, but both variants use the same single-cell 4.2 V charging path, so the calibration reference is still based on voltage rather than capacity.
+
+## Recommended procedure
+
+1. Fully charge the device until the charger indicates completion.
+2. Disconnect USB and let the battery settle for a few minutes.
+3. Wake the device, wait at least 5 seconds, then run `hw battery`.
+4. Repeat the command a few times and keep the lowest stable voltage you observe while the pack is still freshly charged.
+5. Use the lowest stable full-charge reading as the reference when validating or rebuilding firmware. On the boards discussed in issue #334, the plausible range is about `4160-4190 mV`, so `4160 mV` is a safe conservative reference.
+
+## What to look for
+
+- The full-charge voltage should be stable across repeated reads.
+- The `hw battery` command should show `100%` once the settled full-charge voltage is reached.
+- The same command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and percentage.
+- On-device, the battery screen now uses the same health state to color the bar and adds short blink pulses for `low` and `critical` states.
+- LED mapping on the device is:
+
+  | Condition | LED color | Blink behavior |
+  | --- | --- | --- |
+  | `excellent` | cyan | none |
+  | `good` | green | none |
+  | `fair` | yellow | none |
+  | `low` | yellow | 1 extra blink |
+  | `critical` | red | 2 extra blinks |
+
+- If the reported percentage dips below `100%` immediately after a full charge, the curve reference is too high for that board.
+- A reading around `3160 mV` would not be consistent with a fully charged single-cell LiPo, so treat that value as a typo unless you have board-specific evidence to the contrary.
+
+## Notes
+
+- Battery reads are most reliable after wake-up, once the analog path has settled.
+- This project does not currently expose a runtime battery calibration command; calibration is performed by validating the measured full-charge reference used by the firmware curve.

--- a/battery-calibration.md
+++ b/battery-calibration.md
@@ -18,7 +18,8 @@ The Lite uses a smaller button cell than the Ultra, but both variants use the sa
 - The `hw battery` command should show `100%` once the settled full-charge voltage is reached.
 - The protocol also exposes `GET_BATTERY_INFO_EX`, which adds a compact `condition` field to the standard battery payload.
 - The same `hw battery` command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and percentage.
-- On-device, the battery screen now uses the same health state to color the bar and adds short blink pulses for `low` and `critical` states.
+- On-device, the battery screen now uses the same condition state to color the bar and adds short blink pulses for `low` and `critical` states.
+- This condition hint is a practical classification derived from voltage and percentage; it is not a direct measurement of the cell's true state of health or capacity.
 - LED mapping on the device is:
 
   | Condition | LED color | Blink behavior |

--- a/battery-calibration.md
+++ b/battery-calibration.md
@@ -2,6 +2,7 @@
 
 The battery percentage is derived from the reported battery voltage using an empirically tuned curve.
 The default curve is calibrated so that the lowest stable full-charge voltage still maps to 100%.
+This percentage is a state-of-charge estimate, not a direct capacity measurement.
 The Lite uses a smaller button cell than the Ultra, but both variants use the same single-cell 4.2 V charging path, so the calibration reference is still based on voltage rather than capacity.
 
 ## Recommended procedure
@@ -17,9 +18,9 @@ The Lite uses a smaller button cell than the Ultra, but both variants use the sa
 - The full-charge voltage should be stable across repeated reads.
 - The `hw battery` command should show `100%` once the settled full-charge voltage is reached.
 - The protocol also exposes `GET_BATTERY_INFO_EX`, which adds a compact `condition` field to the standard battery payload.
-- The same `hw battery` command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and percentage.
+- The same `hw battery` command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and state-of-charge estimate.
 - On-device, the battery screen now uses the same condition state to color the bar and adds short blink pulses for `low` and `critical` states.
-- This condition hint is a practical classification derived from voltage and percentage; it is not a direct measurement of the cell's true state of health or capacity.
+- This condition hint is a practical classification derived from voltage and state-of-charge; it is not a direct measurement of the cell's true state of health or capacity.
 - LED mapping on the device is:
 
   | Condition | LED color | Blink behavior |
@@ -31,6 +32,14 @@ The Lite uses a smaller button cell than the Ultra, but both variants use the sa
   | `critical` | red | 2 extra blinks |
 
 - If the reported percentage dips below `100%` immediately after a full charge, the curve reference is too high for that board.
+
+## State of charge vs state of health
+
+- **State of charge (SoC)** is the current battery fill estimate, expressed here as the reported percentage and derived from the voltage curve.
+- **State of health (SoH)** is a longer-term measure of how much usable capacity the cell can still deliver compared with its nominal capacity.
+- The current firmware and protocol expose a **health hint**, not a true SoH reading.
+- That hint is useful because it gives users a stable, human-readable status without pretending to measure the battery's long-term condition.
+- In other words: the percentage tells you **how full the battery is now**, while the condition hint tells you **how the current reading should be interpreted**.
 ## Notes
 
 - Battery reads are most reliable after wake-up, once the analog path has settled.

--- a/battery-calibration.md
+++ b/battery-calibration.md
@@ -16,7 +16,8 @@ The Lite uses a smaller button cell than the Ultra, but both variants use the sa
 
 - The full-charge voltage should be stable across repeated reads.
 - The `hw battery` command should show `100%` once the settled full-charge voltage is reached.
-- The same command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and percentage.
+- The protocol also exposes `GET_BATTERY_INFO_EX`, which adds a compact `condition` field to the standard battery payload.
+- The same `hw battery` command now prefers an extended battery-info response and prints a qualitative `condition` hint (`excellent`, `good`, `fair`, `low`, or `critical`) based on the measured voltage and percentage.
 - On-device, the battery screen now uses the same health state to color the bar and adds short blink pulses for `low` and `critical` states.
 - LED mapping on the device is:
 

--- a/protocol.md
+++ b/protocol.md
@@ -246,6 +246,7 @@ Notes: the returned string is the output of `git describe --abbrev=7 --dirty --a
 * CLI: cf `hw battery`
 
 Notes: wait about 5 seconds after wake-up, before querying the battery status, else the device won't be able to give a proper measure and will return zeroes.
+See [[Battery calibration|battery-calibration]] for the recommended procedure and LED health mapping.
 ### 1026: GET_BUTTON_PRESS_CONFIG
 * Command: 1 byte. Char `A` or `B` (`a`/`b` tolerated too)
 * Response: 1 byte, `button_function` according to `settings_button_function_t` enum.

--- a/protocol.md
+++ b/protocol.md
@@ -308,7 +308,7 @@ See [[Battery calibration|battery-calibration]] for the recommended procedure an
 * Response: 4 bytes, `voltage[2]|percentage|condition`. Voltage: U16 in Network byte order.
 * CLI: cf `hw battery`
 
-Notes: `condition` is a compact battery health code derived from the measured voltage and percentage. See [[Battery calibration|battery-calibration]] for the recommended procedure and LED health mapping.
+Notes: `condition` is a compact battery condition hint derived from the measured voltage and percentage. It is not a direct state-of-health measurement based on true battery capacity. See [[Battery calibration|battery-calibration]] for the recommended procedure and LED condition mapping.
 ### 2000: HF14A_SCAN
 * Command: no data
 * Response: N bytes: `tag1_data|tag2_data|...` with each tag: `uidlen|uid[uidlen]|atqa[2]|sak|atslen|ats[atslen]`. UID, ATQA, SAK and ATS as bytes.

--- a/protocol.md
+++ b/protocol.md
@@ -303,6 +303,12 @@ See [[Battery calibration|battery-calibration]] for the recommended procedure an
 * Command: 1 byte, bool = `0x00` or `0x01`
 * Response: no data
 * CLI: cf `hw settings blepair`
+### 1041: GET_BATTERY_INFO_EX
+* Command: no data
+* Response: 4 bytes, `voltage[2]|percentage|condition`. Voltage: U16 in Network byte order.
+* CLI: cf `hw battery`
+
+Notes: `condition` is a compact battery health code derived from the measured voltage and percentage. See [[Battery calibration|battery-calibration]] for the recommended procedure and LED health mapping.
 ### 2000: HF14A_SCAN
 * Command: no data
 * Response: N bytes: `tag1_data|tag2_data|...` with each tag: `uidlen|uid[uidlen]|atqa[2]|sak|atslen|ats[atslen]`. UID, ATQA, SAK and ATS as bytes.

--- a/protocol.md
+++ b/protocol.md
@@ -308,7 +308,7 @@ See [[Battery calibration|battery-calibration]] for the recommended procedure an
 * Response: 4 bytes, `voltage[2]|percentage|condition`. Voltage: U16 in Network byte order.
 * CLI: cf `hw battery`
 
-Notes: `condition` is a compact battery condition hint derived from the measured voltage and percentage. It is not a direct state-of-health measurement based on true battery capacity. See [[Battery calibration|battery-calibration]] for the recommended procedure and LED condition mapping.
+Notes: `condition` is a compact battery condition hint derived from the measured voltage and state-of-charge estimate. It is not a direct state-of-health measurement based on true battery capacity. See [[Battery calibration|battery-calibration]] for the recommended procedure and LED condition mapping.
 ### 2000: HF14A_SCAN
 * Command: no data
 * Response: N bytes: `tag1_data|tag2_data|...` with each tag: `uidlen|uid[uidlen]|atqa[2]|sak|atslen|ats[atslen]`. UID, ATQA, SAK and ATS as bytes.


### PR DESCRIPTION
## Summary
This draft PR adds the battery calibration guide to the Chameleon Ultra docs repository.

It is linked to [firmware PR #439](https://github.com/RfidResearchGroup/ChameleonUltra/pull/439), which introduces the firmware-side battery calibration fix, the battery health hint, and the on-device LED health mapping.

### Included updates
- Adds a dedicated battery calibration guide with the recommended full-charge, settle, and verification procedure.
- Documents the LED health mapping used by the device battery screen.
- Links the guide from the main docs index.
- References the battery calibration guide from the protocol documentation.

## Notes
- The firmware-side behavior is being handled in the companion firmware PR.
- This docs PR intentionally stays focused on the user-facing calibration guidance and documentation links.
